### PR TITLE
Output newline-separated matches with -match-only

### DIFF
--- a/lib/match/match.mli
+++ b/lib/match/match.mli
@@ -68,6 +68,8 @@ type t =
 
 val create : unit -> t
 
+val pp : Format.formatter -> string option * t list -> unit
+
 val pp_json_lines : Format.formatter -> string option * t list -> unit
 
 val pp_match_count : Format.formatter -> string option * t list -> unit

--- a/lib/match/match_context.ml
+++ b/lib/match/match_context.ml
@@ -25,13 +25,29 @@ let to_json source_path matches =
     ; ("matches", json_matches matches)
     ]
 
-let pp_json_lines ppf (source_path, matches) =
-  Format.fprintf ppf "%s" @@ Yojson.Safe.to_string @@ to_json source_path matches
+let pp_source_path ppf source_path =
+  match source_path with
+  | Some path -> Format.fprintf ppf "%s:" path
+  | None -> Format.fprintf ppf ""
+
+let pp ppf (source_path, matches) =
+  if matches = [] then
+    ()
+  else
+    let matched =
+      List.map matches ~f:(fun { matched; _ } ->
+          let matched = String.substr_replace_all matched ~pattern:"\n" ~with_:"\\n" in
+          Format.asprintf "%a%s" pp_source_path source_path matched)
+      |> String.concat ~sep:"\n"
+    in
+    Format.fprintf ppf "%s@." matched
 
 let pp_match_count ppf (source_path, matches) =
-  let pp_source_path ppf source_path =
-    match source_path with
-    | Some path -> Format.fprintf ppf "%s:" path
-    | None -> Format.fprintf ppf ""
-  in
-  Format.fprintf ppf "%a%d matches\n" pp_source_path source_path (List.length matches)
+  let l = List.length matches in
+  if l > 1 then
+    Format.fprintf ppf "%a%d matches\n" pp_source_path source_path (List.length matches)
+  else if l = 1 then
+    Format.fprintf ppf "%a%d match\n" pp_source_path source_path (List.length matches)
+
+let pp_json_lines ppf (source_path, matches) =
+  Format.fprintf ppf "%s" @@ Yojson.Safe.to_string @@ to_json source_path matches

--- a/src/main.ml
+++ b/src/main.ml
@@ -329,15 +329,15 @@ let base_command_parameters : (unit -> 'result) Command.Param.t =
   [%map_open
      (* flags. *)
     let sequential = flag "sequential" no_arg ~doc:"Run sequentially"
-    and match_only = flag "match-only" no_arg ~doc:"Only perform matching (ignore rewrite templates)"
+    and match_only = flag "match-only" no_arg ~doc:"Only perform matching. Put an empty rewrite template as the second argument on the CLI (it is ignored)"
     and verbose = flag "verbose" no_arg ~doc:(Format.sprintf "Log to %s" verbose_out_file)
     and rule = flag "rule" (optional_with_default "where true" string) ~doc:"rule Apply rules to matches."
     and match_timeout = flag "timeout" (optional_with_default 3 int) ~doc:"seconds Set match timeout on a source. Default: 3 seconds"
     and target_directory = flag "directory" ~aliases:["d"; "r"; "recursive"] (optional_with_default (Sys.getcwd ()) string) ~doc:(Format.sprintf "path Run recursively on files in a directory. Default is current directory: %s" @@ Sys.getcwd ())
     and directory_depth = flag "depth" (optional int) ~doc:"n Depth to recursively descend into directories"
     and specification_directories = flag "templates" (optional (Arg_type.comma_separated string)) ~doc:"path CSV of directories containing templates"
-    and file_filters = flag "extensions" ~aliases:["e"; "file-extensions"; "f"] (optional (Arg_type.comma_separated string)) ~doc:"extensions Comma-separated extensions to include, like \".go\" or \".c,.h\". It is just a file suffix, so you can use it to filter file names like \"main.go\". The extension will be used to infer a matcher, unless --custom-matcher or --matcher is specified"
-    and override_matcher = flag "matcher" ~aliases:["m"] (optional string) ~doc:"extension Use this matcher on all files regardless of their file extension, unless a --custom-matcher is specified"
+    and file_filters = flag "extensions" ~aliases:["e"; "file-extensions"; "f"] (optional (Arg_type.comma_separated string)) ~doc:"extensions Comma-separated extensions to include, like \".go\" or \".c,.h\". It is just a file suffix, so you can use it to filter file names like \"main.go\". The extension will be used to infer a matcher, unless -custom-matcher or -matcher is specified"
+    and override_matcher = flag "matcher" ~aliases:["m"] (optional string) ~doc:"extension Use this matcher on all files regardless of their file extension, unless a -custom-matcher is specified"
     and custom_matcher = flag "custom-matcher" (optional string) ~doc:"path Path to a JSON file that contains a custom matcher"
     and zip_file = flag "zip" ~aliases:["z"] (optional string) ~doc:"zipfile A zip file containing files to rewrite"
     and json_lines = flag "json-lines" no_arg ~doc:"Output JSON line format"


### PR DESCRIPTION
- Matches across newlines have newlines converted to `\n`. 