### PR TITLE
Add basic definition for Nim

### DIFF
--- a/lib/matchers/languages.ml
+++ b/lib/matchers/languages.ml
@@ -433,11 +433,10 @@ module Nim = struct
        as type suffixes like 'i8 *)
     let escapable_string_literals = ordinary_string
 
+    (* Not supported: "raw" string literals as defined in https://nim-lang.org/docs/manual.html#lexical-analysis-raw-string-literals where r"a""b" means the two "" are escaped to single *)
+    (* Not supported: generalized raw string literals as in https://nim-lang.org/docs/manual.html#lexical-analysis-raw-string-literals that needs more special casing in the lexer *)
     let raw_string_literals =
       [ ({|"""|}, {|"""|})
-      (* Not supported: "raw" string literals as defined in https://nim-lang.org/docs/manual.html#lexical-analysis-raw-string-literals where r"a""b" means the two "" are escaped to single *)
-      (* Not supported: generalized raw string literals as in https://nim-lang.org/docs/manual.html#lexical-analysis-raw-string-literals that needs more special casing in the lexer *)
-
       ]
 
     let comments =

--- a/lib/matchers/languages.ml
+++ b/lib/matchers/languages.ml
@@ -419,6 +419,37 @@ module Scala = struct
   include Matcher.Make (C.Syntax) (Info)
 end
 
+module Nim = struct
+  module Info = struct
+    let name = "Nim"
+    let extensions = [".nim"]
+  end
+
+  module Syntax = struct
+    include Dyck.Syntax
+
+
+    (* Excludes ' as escapable string literal, since these can be used in
+       as type suffixes like 'i8 *)
+    let escapable_string_literals = ordinary_string
+
+    let raw_string_literals =
+      [ ({|"""|}, {|"""|})
+      (* Not supported: "raw" string literals as defined in https://nim-lang.org/docs/manual.html#lexical-analysis-raw-string-literals where r"a""b" means the two "" are escaped to single *)
+      (* Not supported: generalized raw string literals as in https://nim-lang.org/docs/manual.html#lexical-analysis-raw-string-literals that needs more special casing in the lexer *)
+
+      ]
+
+    let comments =
+      [ Until_newline "#"
+      ; Nested_multiline ("#[", "]#")
+      ]
+  end
+
+  include Matcher.Make (Syntax) (Info)
+end
+
+
 module Dart = struct
   module Info = struct
     let name = "Dart"
@@ -725,6 +756,7 @@ let all : (module Types.Matcher.S) list =
   ; (module Kotlin)
   ; (module Latex)
   ; (module Lisp)
+  ; (module Nim)
   ; (module OCaml)
   ; (module Paren)
   ; (module Pascal)

--- a/test/test_cli.ml
+++ b/test/test_cli.ml
@@ -297,6 +297,7 @@ let%expect_test "list_languages" =
  -matcher .kt       Kotlin    
  -matcher .tex      LaTeX     
  -matcher .lisp     Lisp      
+ -matcher .nim      Nim       
  -matcher .ml       OCaml     
  -matcher .paren    Paren     
  -matcher .pas      Pascal    


### PR DESCRIPTION
Nim is indentation-sensitive, so we can't handle that yet. There's also some special casing for how Nim does generalized raw string literals. But that aside, this adds basic support.