### PR TITLE
Add a flag to substitute environments

### DIFF
--- a/src/main.ml
+++ b/src/main.ml
@@ -77,21 +77,29 @@ let substitute_environment_only_and_exit anonymous_arguments json_environment =
     match anonymous_arguments with
     | Some { rewrite_template; _ } -> rewrite_template
     | None ->
-      Format.eprintf "When the -substitute-only argument is active, a rewrite template must be in the second anonymous argument. For example: comby 'ignored' 'rewrite_template' -substitute-only 'JSON-for-the-environment'.";
+      Format.eprintf
+        "When the -substitute-only argument is active, a rewrite\
+         template must be in the second anonymous argument. For \
+         example: comby 'ignored' 'rewrite_template' \
+         -substitute-only 'JSON-for-the-environment'.";
       exit 1
   in
-  let environment =
-    Yojson.Safe.from_string (Option.value_exn json_environment)
-    |> Match.Environment.of_yojson
-    |> function
-    | Ok environment -> environment
-    | Error err ->
-      Format.eprintf "Error, could not convert input to environment: %s@." err;
-      exit 1
-  in
-  let substituted, _ = Rewriter.Rewrite_template.substitute rewrite_template environment in
-  Format.printf "%s@." substituted;
-  exit 0
+  match Yojson.Safe.from_string (Option.value_exn json_environment) with
+  | json ->
+    begin
+      Match.Environment.of_yojson json
+      |> function
+      | Ok environment ->
+        let substituted, _ = Rewriter.Rewrite_template.substitute rewrite_template environment in
+        Format.printf "%s@." substituted;
+        exit 0
+      | Error err ->
+        Format.eprintf "Error, could not convert input to environment: %s@." err;
+        exit 1
+    end
+  | exception Yojson.Json_error err ->
+    Format.eprintf "Error, could not parse JSON to environment: %s@." err;
+    exit 1
 
 let base_command_parameters : (unit -> 'result) Command.Param.t =
   [%map_open
@@ -115,7 +123,7 @@ let base_command_parameters : (unit -> 'result) Command.Param.t =
     and dump_statistics = flag "statistics" ~aliases:["stats"] no_arg ~doc:"Dump statistics to stderr"
     and stdin = flag "stdin" no_arg ~doc:"Read source from stdin"
     and stdout = flag "stdout" no_arg ~doc:"Print changed content to stdout. Useful to editors for reading in changed content."
-    and substitute_environment_only = flag "substitute-only" (optional string) ~doc:"JSON Substitute the environment specified in JSON into the rewrite template and output the substitution. Do not match or rewrite anything (match templates and inputs are ignored)."
+    and substitute_environment = flag "substitute-only" (optional string) ~doc:"JSON Substitute the environment specified in JSON into the rewrite template and output the substitution. Do not match or rewrite anything (match templates and inputs are ignored)."
     and diff = flag "diff" no_arg ~doc:"Output diff"
     and color = flag "color" no_arg ~doc:"Color matches or replacements (patience diff)."
     and newline_separated_rewrites = flag "newline-separated" no_arg ~doc:"Instead of rewriting in place, output rewrites separated by newlines."
@@ -161,10 +169,8 @@ let base_command_parameters : (unit -> 'result) Command.Param.t =
           { match_template; rewrite_template; file_filters })
     in
     if list then list_supported_languages_and_exit ();
-    if Option.is_some substitute_environment_only then
-      substitute_environment_only_and_exit
-        anonymous_arguments
-        substitute_environment_only;
+    if Option.is_some substitute_environment then
+      substitute_environment_only_and_exit anonymous_arguments substitute_environment;
     let interactive_review =
       let default_editor =
         let f = Option.some in

--- a/src/main.ml
+++ b/src/main.ml
@@ -72,6 +72,27 @@ let list_supported_languages_and_exit () =
   Format.printf "%s%!" list;
   exit 0
 
+let substitute_environment_only_and_exit anonymous_arguments json_environment =
+  let rewrite_template =
+    match anonymous_arguments with
+    | Some { rewrite_template; _ } -> rewrite_template
+    | None ->
+      Format.eprintf "When the -substitute-only argument is active, a rewrite template must be in the second anonymous argument. For example: comby 'ignored' 'rewrite_template' -substitute-only 'JSON-for-the-environment'.";
+      exit 1
+  in
+  let environment =
+    Yojson.Safe.from_string (Option.value_exn json_environment)
+    |> Match.Environment.of_yojson
+    |> function
+    | Ok environment -> environment
+    | Error err ->
+      Format.eprintf "Error, could not convert input to environment: %s@." err;
+      exit 1
+  in
+  let substituted, _ = Rewriter.Rewrite_template.substitute rewrite_template environment in
+  Format.printf "%s@." substituted;
+  exit 0
+
 let base_command_parameters : (unit -> 'result) Command.Param.t =
   [%map_open
      (* flags. *)
@@ -94,6 +115,7 @@ let base_command_parameters : (unit -> 'result) Command.Param.t =
     and dump_statistics = flag "statistics" ~aliases:["stats"] no_arg ~doc:"Dump statistics to stderr"
     and stdin = flag "stdin" no_arg ~doc:"Read source from stdin"
     and stdout = flag "stdout" no_arg ~doc:"Print changed content to stdout. Useful to editors for reading in changed content."
+    and substitute_environment_only = flag "substitute-only" (optional string) ~doc:"JSON Substitute the environment specified in JSON into the rewrite template and output the substitution. Do not match or rewrite anything (match templates and inputs are ignored)."
     and diff = flag "diff" no_arg ~doc:"Output diff"
     and color = flag "color" no_arg ~doc:"Color matches or replacements (patience diff)."
     and newline_separated_rewrites = flag "newline-separated" no_arg ~doc:"Instead of rewriting in place, output rewrites separated by newlines."
@@ -139,6 +161,10 @@ let base_command_parameters : (unit -> 'result) Command.Param.t =
           { match_template; rewrite_template; file_filters })
     in
     if list then list_supported_languages_and_exit ();
+    if Option.is_some substitute_environment_only then
+      substitute_environment_only_and_exit
+        anonymous_arguments
+        substitute_environment_only;
     let interactive_review =
       let default_editor =
         let f = Option.some in

--- a/src/main.ml
+++ b/src/main.ml
@@ -78,10 +78,9 @@ let substitute_environment_only_and_exit anonymous_arguments json_environment =
     | Some { rewrite_template; _ } -> rewrite_template
     | None ->
       Format.eprintf
-        "When the -substitute-only argument is active, a rewrite\
-         template must be in the second anonymous argument. For \
-         example: comby 'ignored' 'rewrite_template' \
-         -substitute-only 'JSON-for-the-environment'.";
+        "When the -substitute-only argument is active, a rewrite template must \
+         be in the second anonymous argument. For example: `comby 'ignored' \
+         'rewrite_template' -substitute-only 'JSON-for-the-environment'`.";
       exit 1
   in
   match Yojson.Safe.from_string (Option.value_exn json_environment) with

--- a/test/test_cli.ml
+++ b/test/test_cli.ml
@@ -924,13 +924,13 @@ Invalid token 'json'
 let%expect_test "substitute_ok" =
   let source = "a match1 c d a match2 c d" in
   let match_template = "ignored" in
-  let rewrite_template = "a :[1] c d" in
-  let environment = {|[{"variable":"1","value":"match1","range":{"start":{"offset":2,"line":1,"column":3},"end":{"offset":8,"line":1,"column":9}}}]|} in
+  let rewrite_template = ":[1] :[2]" in
+  let environment = {|[{"variable":"1","value":"hole_1"},{"variable":"2","value":"hole_2"}]|} in
   let command_args =
     Format.sprintf "'%s' '%s' -stdin -match-only -matcher .txt -substitute '%s'" match_template rewrite_template environment
   in
   let command = Format.sprintf "%s %s" binary_path command_args in
   read_expect_stdin_and_stdout command source
   |> print_string;
-  [%expect_exact {|a match1 c d
+  [%expect_exact {|hole_1 hole_2
 |}]


### PR DESCRIPTION
Adds `-substitute` which only substitutes an environment (specified in JSON) into a single rewrite template on the command line.

```
comby 'ignored' ':[1] :[2]' -substitute '[{"variable":"1","value":"hole_1"},{"variable":"2","value":"hole_2"}]'
```

---

The JSON environments output by`-match-only` flags can be used directly with the `-substitute` flag (the `range` fields are simply ignored).

Step 1: Get JSON matches

```
echo "a match1 c d a match2 c d" | \
./comby 'a :[1] c d' '' -stdin -matcher .generic -json-lines -match-only \
| jq -c '.matches | map(.environment) | .[]'
```

Outputs JSON environments:

```
[{"variable":"1","value":"match1","range":{"start":{"offset":2,"line":1,"column":3},"end":{"offset":8,"line":1,"column":9}}}]
[{"variable":"1","value":"match2","range":{"start":{"offset":15,"line":1,"column":16},"end":{"offset":21,"line":1,"column":22}}}]
```

Substitute rewrite_template with the env on the first line above:

```
./comby 'ignored_match_template' 'derp :[1] derp' -substitute-only '[{"variable":"1","value":"match1","range":{"start":{"offset":2,"line":1,"column":3},"end":{"offset":8,"line":1,"column":9}}}]'
```

Outputs:

`derp match1 derp`
