### PR TITLE
Fix build with latest bisect_ppx release

### DIFF
--- a/lib/configuration/dune
+++ b/lib/configuration/dune
@@ -1,5 +1,5 @@
 (library
   (name configuration)
   (public_name comby.configuration)
-  (preprocess (pps ppx_deriving.show ppx_sexp_conv ppx_sexp_message ppx_deriving_yojson bisect_ppx --conditional))
+  (preprocess (pps ppx_deriving.show ppx_sexp_conv ppx_sexp_message ppx_deriving_yojson bisect_ppx -conditional))
   (libraries camlzip comby.statistics comby.parsers comby.match comby.language ppxlib core core.uuid mparser mparser.pcre yojson ppx_deriving_yojson hack_parallel))

--- a/lib/dune
+++ b/lib/dune
@@ -1,7 +1,7 @@
 (library
   (name comby)
   (public_name comby)
-  (preprocess (pps ppx_deriving.show ppx_deriving.eq ppx_sexp_conv bisect_ppx --conditional))
+  (preprocess (pps ppx_deriving.show ppx_deriving.eq ppx_sexp_conv bisect_ppx -conditional))
   (libraries 
    ppxlib 
    core 

--- a/lib/language/dune
+++ b/lib/language/dune
@@ -1,5 +1,5 @@
 (library
   (name language)
   (public_name comby.language)
-  (preprocess (pps ppx_sexp_conv bisect_ppx --conditional))
+  (preprocess (pps ppx_sexp_conv bisect_ppx -conditional))
   (libraries comby.parsers comby.match comby.rewriter ppxlib core core.uuid))

--- a/lib/match/dune
+++ b/lib/match/dune
@@ -1,5 +1,5 @@
 (library
   (name match)
   (public_name comby.match)
-  (preprocess (pps ppx_deriving.eq ppx_sexp_conv ppx_deriving_yojson bisect_ppx --conditional))
+  (preprocess (pps ppx_deriving.eq ppx_sexp_conv ppx_deriving_yojson bisect_ppx -conditional))
   (libraries comby.parsers ppxlib core yojson ppx_deriving_yojson ppx_deriving_yojson.runtime))

--- a/lib/matchers/dune
+++ b/lib/matchers/dune
@@ -4,5 +4,5 @@
 (library
   (name matchers)
   (public_name comby.matchers)
-  (preprocess (pps ppx_here ppx_sexp_conv ppx_sexp_message ppx_deriving_yojson bisect_ppx --conditional))
+  (preprocess (pps ppx_here ppx_sexp_conv ppx_sexp_message ppx_deriving_yojson bisect_ppx -conditional))
   (libraries comby.parsers comby.match angstrom ppxlib core core.uuid mparser mparser.pcre yojson ppx_deriving_yojson))

--- a/lib/parsers/dune
+++ b/lib/parsers/dune
@@ -1,5 +1,5 @@
 (library
   (name parsers)
   (public_name comby.parsers)
-  (preprocess (pps ppx_sexp_conv bisect_ppx --conditional))
+  (preprocess (pps ppx_sexp_conv bisect_ppx -conditional))
   (libraries angstrom ppxlib core mparser mparser.pcre))

--- a/lib/pipeline/dune
+++ b/lib/pipeline/dune
@@ -1,5 +1,5 @@
 (library
   (name pipeline)
   (public_name comby.pipeline)
-  (preprocess (pps ppx_sexp_conv ppx_deriving_yojson bisect_ppx --conditional))
+  (preprocess (pps ppx_sexp_conv ppx_deriving_yojson bisect_ppx -conditional))
   (libraries comby.interactive comby.statistics comby.parsers comby.match comby.language camlzip ppxlib core yojson ppx_deriving_yojson hack_parallel))

--- a/lib/replacement/dune
+++ b/lib/replacement/dune
@@ -1,5 +1,5 @@
 (library
   (name replacement)
   (public_name comby.replacement)
-  (preprocess (pps ppx_deriving_yojson bisect_ppx --conditional))
+  (preprocess (pps ppx_deriving_yojson bisect_ppx -conditional))
   (libraries comby.match ppxlib core yojson ppx_deriving_yojson ppx_deriving_yojson.runtime patdiff.lib))

--- a/lib/rewriter/dune
+++ b/lib/rewriter/dune
@@ -1,5 +1,5 @@
 (library
   (name rewriter)
   (public_name comby.rewriter)
-  (preprocess (pps ppx_deriving_yojson bisect_ppx --conditional))
+  (preprocess (pps ppx_deriving_yojson bisect_ppx -conditional))
   (libraries comby.matchers comby.replacement ppxlib core core.uuid))

--- a/lib/server/dune
+++ b/lib/server/dune
@@ -1,5 +1,5 @@
 (library
   (name server_types)
   (public_name comby.server_types)
-  (preprocess (pps ppx_deriving.show ppx_deriving_yojson bisect_ppx --conditional))
+  (preprocess (pps ppx_deriving.show ppx_deriving_yojson bisect_ppx -conditional))
   (libraries comby.match comby.replacement ppxlib core yojson ppx_deriving_yojson ppx_deriving_yojson.runtime))

--- a/lib/statistics/dune
+++ b/lib/statistics/dune
@@ -1,5 +1,5 @@
 (library
   (name statistics)
   (public_name comby.statistics)
-  (preprocess (pps ppx_deriving_yojson bisect_ppx --conditional))
+  (preprocess (pps ppx_deriving_yojson bisect_ppx -conditional))
   (libraries yojson ppx_deriving_yojson ppx_deriving_yojson.runtime))


### PR DESCRIPTION
Comby depends on the latest, unreleased version of the bisect_ppx package [1]. However, system package managers might prefer to use the latest released version of packages. Building Comby with bisect_ppx version 1.4.1 fails:

             ppx lib/configuration/diff_configuration.pp.ml (exit 2)
    (cd _build/default && .ppx/[snip]/ppx.exe --conditional --cookie 'library-name="configuration"' [snip])
    .ppx/[snip]/ppx.exe: unknown option '--conditional'.

Make Comby compatible with bisect_ppx's latest release (version 1.4.1), making it easier for distributions to package Comby. Comby should still build with the latest unreleased version of bisect_ppx.

[1] In particular, Comby relies on at least this commit of bisect_ppx:
    https://github.com/aantron/bisect_ppx/commit/68eea88ae65fd1aee137bcca8657189a91b7416b