### PR TITLE
Fix compilation errors due to monomorphic Core.(=)

### DIFF
--- a/lib/configuration/command_configuration.ml
+++ b/lib/configuration/command_configuration.ml
@@ -1,6 +1,7 @@
 open Core
 
 open Language
+open Poly
 
 let debug =
   Sys.getenv "DEBUG_COMBY"

--- a/lib/match/match_context.ml
+++ b/lib/match/match_context.ml
@@ -1,4 +1,5 @@
 open Core
+open Poly
 
 type t =
   { range : Range.t

--- a/lib/matchers/alpha/matcher.ml
+++ b/lib/matchers/alpha/matcher.ml
@@ -6,6 +6,7 @@ open Match
 open Range
 open Location
 open Types
+open Poly
 
 let configuration_ref = ref (Configuration.create ())
 let weaken_delimiter_hole_matching = false

--- a/lib/matchers/languages.ml
+++ b/lib/matchers/languages.ml
@@ -1,6 +1,7 @@
 open Core
 
 open Types.Syntax
+open Poly
 
 let ordinary_string = Some { delimiters = [{|"|}]; escape_character = '\\' }
 

--- a/lib/matchers/types.ml
+++ b/lib/matchers/types.ml
@@ -1,4 +1,5 @@
 open Core
+open Poly
 
 module Syntax = struct
 

--- a/lib/rewriter/rewrite.ml
+++ b/lib/rewriter/rewrite.ml
@@ -2,6 +2,7 @@ open Core
 
 open Match
 open Replacement
+open Poly
 
 let debug =
   Sys.getenv "DEBUG_COMBY"

--- a/lib/server/server_types.ml
+++ b/lib/server/server_types.ml
@@ -1,6 +1,7 @@
 open Core
 
 open Match
+open Poly
 
 module In = struct
 

--- a/src/benchmark.ml
+++ b/src/benchmark.ml
@@ -1,4 +1,5 @@
 open Core
+open Poly
 
 module Time = Core_kernel.Time_ns.Span
 

--- a/src/main.ml
+++ b/src/main.ml
@@ -3,6 +3,7 @@ open Command.Let_syntax
 open Hack_parallel
 
 open Pipeline.Command_configuration
+open Poly
 
 let verbose_out_file = "/tmp/comby.out"
 


### PR DESCRIPTION
When I build Comby on my machine, the build fails with various errors, including the following:

    File "lib/match/match_context.ml", line 34, characters 7-14:
    34 |     if matches = [] then
                ^^^^^^^
    Error: This expression has type t list but an expression was expected of type
             Core_kernel__Int.t = int

    File "src/benchmark.ml", line 50, characters 5-12:
    50 |   if delta_x < 1.0 then begin
              ^^^^^^^
    Error: This expression has type float but an expression was expected of type
             Core_kernel.Int.t = int

    File "src/main.ml", line 33, characters 18-34:
    33 |       | None when matcher_override <> ".generic" ->
                           ^^^^^^^^^^^^^^^^
    Error: This expression has type string but an expression was expected of type
             Core_kernel__Int.t = int

    File "lib/configuration/command_configuration.ml", line 16, characters 7-32:
    16 |     if Sys.is_file absolute_path = `Yes then
                ^^^^^^^^^^^^^^^^^^^^^^^^^
    Error: This expression has type [ `No | `Unknown | `Yes ]
           but an expression was expected of type Core_kernel__Int.t = int

    File "lib/matchers/languages.ml", line 786, characters 66-81:
    786 |   List.find all ~f:(fun (module M) -> List.exists M.extensions ~f:((=) extension))
                                                                            ^^^^^^^^^^^^^^^
    Error: This expression has type Core_kernel__Int.t -> bool
           but an expression was expected of type string -> bool
           Type Core_kernel__Int.t = int is not compatible with type string

    File "lib/matchers/alpha/matcher.ml", line 306, characters 7-89:
    Error: This expression has type (Core_kernel__Int.t * 'a) list -> 'a option
           but an expression was expected of type (string * string) list -> 'b
           Type Core_kernel__Int.t = int is not compatible with type string

    File "lib/matchers/types.ml", lines 17-23, characters 2-21:
    17 | ..type t = {
    18 |     user_defined_delimiters : (string * string) list;
    19 |     escapable_string_literals : escapable_string_literals option; [@default None]
    20 |     raw_string_literals : (string * string) list;
    21 |     comments : comment_kind list;
    22 |   }
    23 |   [@@deriving yojson]
    Error: This expression has type escapable_string_literals option
           but an expression was expected of type Core_kernel__Int.t = int

    File "lib/server/server_types.ml", lines 14-21, characters 2-21:
    14 | ..type match_request =
    15 |     { source : string
    16 |     ; match_template : string [@key "match"]
    17 |     ; rule : string option [@default None]
    18 |     ; language : string [@default "generic"]
    19 |     ; id : int
    20 |     }
    21 |   [@@deriving yojson]
    Error: This expression has type string but an expression was expected of type
             Core_kernel__Int.t = int

Warning: I'm unfamiliar with OCaml, so the following explanation may be incorrect.

`open Core` imports a definition of the `(=)` function (and other comparison functions) which shadows the built-in `(=)` function. This causes comparisons between floats, strings, lists, and other types to fail to compile. https://github.com/ocaml-ppx/ppx_deriving_yojson/issues/79 seems related, but the issue is also present in code which doesn't use ppx_deriving_yojson.

Make `(=)` and other comparison functions work as expected with `open Poly`. (I don't know what this does exactly, but it fixes the build errors on my machine.)