### PR TITLE
Add missing dependency on shell.filename_extended

### DIFF
--- a/comby.opam
+++ b/comby.opam
@@ -16,6 +16,7 @@ depends: [
   "mparser-comby"
   "ppxlib"
   "ppx_deriving"
+  "shell"
   "angstrom"
   "hack_parallel"
   "opium"

--- a/lib/interactive/dune
+++ b/lib/interactive/dune
@@ -2,4 +2,4 @@
   (name interactive)
   (public_name comby.interactive)
   (preprocess (pps ppx_sexp_conv))
-  (libraries comby.configuration comby.match ppxlib core core.uuid lwt lwt.unix))
+  (libraries comby.configuration comby.match ppxlib shell.filename_extended core core.uuid lwt lwt.unix))


### PR DESCRIPTION
Comby uses the Filename_extended module, but does not depend on any packages which define that module. This causes a build failure on my machine:

    File "lib/interactive/interactive.ml", line 255, characters 17-48:
    255 |       let path = Filename_extended.make_relative path in
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    Error: Unbound module Filename_extended

Fix the error by depending on required packages.