### PR TITLE
Remove spurious dependency on lambda-term

### DIFF
--- a/comby.opam
+++ b/comby.opam
@@ -25,7 +25,6 @@ depends: [
   "camlzip"
   "patdiff"
   "lwt_react"
-  "lambda-term"
   "ppx_deriving_yojson"
   "ppx_tools_versioned" {>= "5.2.3"}
   "bisect_ppx" {dev & >= "2.0.0"}


### PR DESCRIPTION
Git commit 516bcf9d2aaea1729d65846fa0fef3d94f94752d removed Comby's use of the lambda-term package. That commit left a dangling reference to lamda-term in comby.opam, though. Remove that dangling reference.