### PR TITLE
README.md Add `-a stderr` to `docker`

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@
 Running with docker on `stdin`:
 
 ```bash
-echo '(👋 hi)' | docker run -a stdin -a stdout -a stderr -i comby/comby '(:[emoji] hi)' 'bye :[emoji]' lisp -stdin
+docker run -a stdin -a stdout -a stderr -i comby/comby '(:[emoji] hi)' 'bye :[emoji]' lisp -stdin <<< '(👋 hi)'
 ```
 
 <img width="500" src="https://user-images.githubusercontent.com/888624/64924862-0edf1a00-d7b7-11e9-9c2e-cfeafde5bb4b.png">

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@
 Running with docker on `stdin`:
 
 ```bash
-echo '(👋 hi)' | docker run -a stdin -a stdout -i comby/comby '(:[emoji] hi)' 'bye :[emoji]' lisp -stdin
+echo '(👋 hi)' | docker run -a stdin -a stdout -a stderr -i comby/comby '(:[emoji] hi)' 'bye :[emoji]' lisp -stdin
 ```
 
 <img width="500" src="https://user-images.githubusercontent.com/888624/64924862-0edf1a00-d7b7-11e9-9c2e-cfeafde5bb4b.png">


### PR DESCRIPTION
Without it `comby` just fails silently.