### PR TITLE
Comments in template imply whitespace

### DIFF
--- a/lib/matchers/alpha/matcher.ml
+++ b/lib/matchers/alpha/matcher.ml
@@ -110,14 +110,14 @@ module Make (Syntax : Syntax.S) (Info : Info.S) = struct
   let raw_literal_grammar ~right_delimiter =
     is_not (string right_delimiter) |>> String.of_char
 
+  let generate_comment_parser _ =
+    (comment_parser >>= fun result -> f result)
+
   let generate_spaces_parser () =
     (* At least a space followed by comments and spaces. *)
     (spaces1
-     >> many comment_parser << spaces
      >>= fun result -> f result)
-    <|>
-    (* This case not covered by tests, may not be needed. *)
-    (many1 comment_parser << spaces >>= fun result -> f result)
+
 
   let sequence_chain (plist : ('c, Match.t) parser sexp_list) : ('c, Match.t) parser =
     List.fold plist ~init:(return Unit) ~f:(>>)
@@ -297,10 +297,18 @@ module Make (Syntax : Syntax.S) (Info : Info.S) = struct
       List.concat_map Syntax.raw_string_literals ~f:(fun (from, until) -> [from; until])
       |> List.map ~f:string
     in
+    let reserved_comments =
+      List.concat_map Syntax.comments ~f:(function
+          | Multiline (left, right) -> [left; right]
+          | Nested_multiline (left, right) -> [left; right]
+          | Until_newline start -> [start])
+      |> List.map ~f:string
+    in
     reserved_holes ()
     @ reserved_delimiters
     @ reserved_escapable_strings
     @ reserved_raw_strings
+    @ reserved_comments
     |> List.map ~f:skip
     (* Attempt the reserved: otherwise, if a parser partially succeeds,
        it won't detect that single or greedy is reserved. *)
@@ -761,6 +769,7 @@ module Make (Syntax : Syntax.S) (Info : Info.S) = struct
                   [(attempt optional_succeeds_parser)
                    <|> optional_fails_parser]
           end
+        | Success Unit -> acc (* for comment *)
         | Success _ -> failwith "Hole expected")
 
   let hole_parser sort dimension =
@@ -823,8 +832,11 @@ module Make (Syntax : Syntax.S) (Info : Info.S) = struct
       ; escapable_string_literal_parser (generate_hole_for_literal Escapable_string_literal)
       (* Nested delimiters are handled specially for nestedness. *)
       ; nested_delimiters_parser generate_outer_delimiter_parsers
+      (* Skip comments in the template, make them just succeed matching. could
+         also return the comment string, but that's a bit strong. *)
+      ; (comment_parser |>> fun _ -> generate_comment_parser ())
       (* Whitespace is handled specially because we may change whether they are significant for matching. *)
-      ; spaces1 |>> generate_spaces_parser
+      ; (spaces1 |>> fun s -> generate_spaces_parser s)
       (* Optional: parse identifiers and disallow substring matching *)
       ; if !configuration_ref.disable_substring_matching then many1 (alphanum <|> char '_') |>> generate_word else zero
       (* Everything else. *)

--- a/test/common/test_c.ml
+++ b/test/common/test_c.ml
@@ -22,7 +22,7 @@ let%expect_test "comments_1" =
   let rewrite_template = {|:[1]|} in
 
   run source match_template rewrite_template;
-  [%expect_exact {|expect|}]
+  [%expect_exact {|/**/ expect|}]
 
 let%expect_test "comments_2" =
   let source = {|match this /* */ expect end|} in
@@ -30,7 +30,7 @@ let%expect_test "comments_2" =
   let rewrite_template = {|:[1]|} in
 
   run source match_template rewrite_template;
-  [%expect_exact {|expect|}]
+  [%expect_exact {|/* */ expect|}]
 
 let%expect_test "comments_3" =
   let source = {|match this /* blah blah */ expect /**/ end|} in
@@ -38,7 +38,7 @@ let%expect_test "comments_3" =
   let rewrite_template = {|:[1]|} in
 
   run source match_template rewrite_template;
-  [%expect_exact {|expect|}]
+  [%expect_exact {|/* blah blah */ expect /**/|}]
 
 let%expect_test "comments_4" =
   let source = {|match this expect/**/end|} in

--- a/test/common/test_c.ml
+++ b/test/common/test_c.ml
@@ -22,7 +22,7 @@ let%expect_test "comments_1" =
   let rewrite_template = {|:[1]|} in
 
   run source match_template rewrite_template;
-  [%expect_exact {|/**/ expect|}]
+  [%expect_exact {|expect|}]
 
 let%expect_test "comments_2" =
   let source = {|match this /* */ expect end|} in
@@ -30,7 +30,7 @@ let%expect_test "comments_2" =
   let rewrite_template = {|:[1]|} in
 
   run source match_template rewrite_template;
-  [%expect_exact {|/* */ expect|}]
+  [%expect_exact {|expect|}]
 
 let%expect_test "comments_3" =
   let source = {|match this /* blah blah */ expect /**/ end|} in
@@ -38,7 +38,7 @@ let%expect_test "comments_3" =
   let rewrite_template = {|:[1]|} in
 
   run source match_template rewrite_template;
-  [%expect_exact {|/* blah blah */ expect /**/|}]
+  [%expect_exact {|expect|}]
 
 let%expect_test "comments_4" =
   let source = {|match this expect/**/end|} in

--- a/test/common/test_c_style_comments.ml
+++ b/test/common/test_c_style_comments.ml
@@ -56,8 +56,6 @@ let%expect_test "rewrite_comments_2" =
   |> print_string;
   [%expect_exact
     {|
-      /* if (fake_condition_body_must_be_non_empty) { fake_body; } */
-      // if (fake_condition_body_must_be_non_empty) { fake_body; }
       if (real_condition_body_must_be_empty) {}
     |}]
 
@@ -83,9 +81,9 @@ let%expect_test "capture_comments" =
       },
       {
         "variable": "2",
-        "value": "/* some comment */ console.log(z);",
+        "value": "console.log(z);",
         "range": {
-          "start": { "offset": 12, "line": 1, "column": 13 },
+          "start": { "offset": 31, "line": 1, "column": 32 },
           "end": { "offset": 46, "line": 1, "column": 47 }
         }
       }
@@ -118,7 +116,6 @@ let%expect_test "single_quote_in_comment" =
   |> print_string;
   [%expect_exact
     {|
-       /*'*/
       {test}
     |}]
 


### PR DESCRIPTION
Previously, interpolated whitespace/comments implied a one-to-one matching in template to source. Now, comments or whitespace in template will consume either whitespace or comments in source.