### PR TITLE
Comments imply whitespace

### DIFF
--- a/lib/matchers/alpha.ml
+++ b/lib/matchers/alpha.ml
@@ -115,13 +115,11 @@ module Make (Syntax : Syntax.S) (Info : Info.S) = struct
     is_not (string right_delimiter) |>> String.of_char
 
   let generate_spaces_parser () =
-    (* At least a space followed by comments and spaces. *)
-    (spaces1
-     >> many comment_parser << spaces
-     >>= fun result -> f result)
-    <|>
-    (* This case not covered by tests, may not be needed. *)
-    (many1 comment_parser << spaces >>= fun result -> f result)
+    many1 @@ choice
+      [ skip comment_parser
+      ; spaces1
+      ]
+    >>= fun _ -> f Unit
 
   let sequence_chain (plist : ('c, Match.t) parser sexp_list) : ('c, Match.t) parser =
     List.fold plist ~init:(return Unit) ~f:(>>)
@@ -322,10 +320,18 @@ module Make (Syntax : Syntax.S) (Info : Info.S) = struct
       List.concat_map Syntax.raw_string_literals ~f:(fun (from, until) -> [from; until])
       |> List.map ~f:string
     in
+    let reserved_comments =
+      List.concat_map Syntax.comments ~f:(function
+          | Multiline (left, right) -> [left; right]
+          | Nested_multiline (left, right) -> [left; right]
+          | Until_newline start -> [start])
+      |> List.map ~f:string
+    in
     reserved_holes ()
     @ reserved_delimiters
     @ reserved_escapable_strings
     @ reserved_raw_strings
+    @ reserved_comments
     |> List.map ~f:skip
     (* Attempt the reserved: otherwise, if a parser partially succeeds,
        it won't detect that single or greedy is reserved. *)
@@ -826,6 +832,7 @@ module Make (Syntax : Syntax.S) (Info : Info.S) = struct
                   [(attempt optional_succeeds_parser)
                    <|> optional_fails_parser]
           end
+        | Success Unit -> acc (* for comment *)
         | Success _ -> failwith "Hole expected")
 
   let hole_parser sort dimension =
@@ -889,8 +896,8 @@ module Make (Syntax : Syntax.S) (Info : Info.S) = struct
       ; escapable_string_literal_parser (generate_hole_for_literal Escapable_string_literal)
       (* Nested delimiters are handled specially for nestedness. *)
       ; nested_delimiters_parser generate_outer_delimiter_parsers
-      (* Whitespace is handled specially because we may change whether they are significant for matching. *)
-      ; spaces1 |>> generate_spaces_parser
+      (* Skip comments in the template, just succeed. If desired, could return the comment string. *)
+      ; (many1 (skip comment_parser <|> spaces1) |>> fun _ -> generate_spaces_parser ())
       (* Optional: parse identifiers and disallow substring matching *)
       ; if !configuration_ref.disable_substring_matching then many1 (alphanum <|> char '_') |>> generate_word else zero
       (* Everything else. *)

--- a/lib/matchers/omega.ml
+++ b/lib/matchers/omega.ml
@@ -330,8 +330,8 @@ module Make (Syntax : Syntax.S) (Info : Info.S) = struct
         let result =
           if debug then Format.printf "iterate fold_right %d@." !i;
           match parse_string p "_signal_hole" with
-          | Error _ ->
-            if debug then Format.printf "Composing p with terminating parser@.";
+          | Error s ->
+            if debug then Format.printf "Composing p with terminating parser, error %s@." s;
             p *> acc
           | Ok (Hole { sort; identifier; dimension; _ }, user_state) ->
             begin
@@ -564,10 +564,12 @@ module Make (Syntax : Syntax.S) (Info : Info.S) = struct
   let generate_spaces_parser _ignored =
     (* XXX still some parts ignored in the choice case in Alpha *)
     if debug then Format.printf "Template_spaces(%s)@." _ignored;
-    spaces1 >>= fun s1 ->
-    many comment_parser >>= fun result ->
-    spaces >>= fun s2 ->
-    r acc (Template_string (s1^String.concat result^s2))
+    many1 @@
+    choice
+      [ comment_parser
+      ; spaces1
+      ] >>= fun result ->
+    r acc (Template_string (String.concat result))
 
   (** All code can have comments interpolated *)
   let generate_string_token_parser str =
@@ -650,7 +652,9 @@ module Make (Syntax : Syntax.S) (Info : Info.S) = struct
                 not fail here"
 
   let general_parser_generator : (production * 'a) t t =
-    let spaces : (production * 'a) t t = spaces1 |>> generate_spaces_parser in
+    let spaces : (production * 'a) t t =
+      many1 (comment_parser <|> spaces1) |>> fun result -> generate_spaces_parser (String.concat result)
+    in
     let other =
       (many1 (Parser.Deprecate.any_char_except ~reserved:Deprecate.reserved) |>> String.of_char_list)
       |>> generate_string_token_parser

--- a/test/common/test_c_style_comments_alpha.ml
+++ b/test/common/test_c_style_comments_alpha.ml
@@ -51,7 +51,6 @@ let%expect_test "rewrite_comments_2" =
   |> print_string;
   [%expect_exact
     {|
-      /* if (fake_condition_body_must_be_non_empty) { fake_body; } */
       if (real_condition_body_must_be_empty) {}
     |}]
 
@@ -214,3 +213,31 @@ let%expect_test "give_back_the_comment_characters_for_newline_comments_too" =
          // a comment
        }
     |}]
+
+let%expect_test "comments_in_templates_imply_whitespace" =
+  let template =
+    {|
+/* f */
+// q
+a
+|}
+  in
+
+  let source =
+    {|
+// idgaf
+/* fooo */
+a
+|}
+  in
+
+  let rewrite_template =
+    {|erased|}
+  in
+
+  all template source
+  |> (fun matches -> Option.value_exn (Rewrite.all ~source ~rewrite_template matches))
+  |> (fun { rewritten_source; _ } -> rewritten_source)
+  |> print_string;
+  [%expect_exact
+    {|erased|}]

--- a/test/common/test_c_style_comments_omega.ml
+++ b/test/common/test_c_style_comments_omega.ml
@@ -51,7 +51,6 @@ let%expect_test "rewrite_comments_2" =
   |> print_string;
   [%expect_exact
     {|
-      /* if (fake_condition_body_must_be_non_empty) { fake_body; } */
       if (real_condition_body_must_be_empty) {}
     |}]
 
@@ -214,3 +213,31 @@ let%expect_test "give_back_the_comment_characters_for_newline_comments_too" =
          // a comment
        }
     |}]
+
+let%expect_test "comments_in_templates_imply_whitespace" =
+  let template =
+    {|
+/* f */
+// q
+a
+|}
+  in
+
+  let source =
+    {|
+// idgaf
+/* fooo */
+a
+|}
+  in
+
+  let rewrite_template =
+    {|erased|}
+  in
+
+  all template source
+  |> (fun matches -> Option.value_exn (Rewrite.all ~source ~rewrite_template matches))
+  |> (fun { rewritten_source; _ } -> rewritten_source)
+  |> print_string;
+  [%expect_exact
+    {|erased|}]


### PR DESCRIPTION
Previously, interpolated whitespace/comments implied a one-to-one matching in template to source. Now, comments or whitespace in template will consume either whitespace or comments in source.