### PR TITLE
add flag to cut off newline matching at top level

### DIFF
--- a/lib/configuration/command_configuration.ml
+++ b/lib/configuration/command_configuration.ml
@@ -238,6 +238,7 @@ type run_options =
   ; disable_substring_matching : bool
   ; omega : bool
   ; fast_offset_conversion : bool
+  ; cut_off_newline : bool
   }
 
 type user_input =
@@ -672,6 +673,7 @@ let create
          ; disable_substring_matching
          ; omega
          ; fast_offset_conversion
+         ; cut_off_newline
          }
      ; output_options =
          ({ overwrite_file_in_place
@@ -790,6 +792,7 @@ let create
         ; disable_substring_matching
         ; omega
         ; fast_offset_conversion
+        ; cut_off_newline
         }
     ; output_printer
     ; interactive_review

--- a/lib/configuration/command_configuration.mli
+++ b/lib/configuration/command_configuration.mli
@@ -65,6 +65,7 @@ type run_options =
   ; disable_substring_matching : bool
   ; omega : bool
   ; fast_offset_conversion : bool
+  ; cut_off_newline : bool
   }
 
 type user_input =

--- a/lib/matchers/alpha.ml
+++ b/lib/matchers/alpha.ml
@@ -856,6 +856,7 @@ module Make (Syntax : Syntax.S) (Info : Info.S) = struct
       | Regex -> regex_hole_parser ()
     in
     let skip_signal hole = skip (string "_signal_hole") |>> fun () -> Hole hole in
+    let at_depth = if not !configuration_ref.cut_off_top_level_newline_matching then None else at_depth in
     hole_parser |>> fun (optional, identifier) -> skip_signal { sort; identifier; dimension; optional; at_depth }
 
   let generate_hole_for_literal sort ~contents ~left_delimiter ~right_delimiter s =
@@ -902,7 +903,7 @@ module Make (Syntax : Syntax.S) (Info : Info.S) = struct
       |> List.map ~f:(fun kind -> attempt (hole_parser kind Code ~at_depth))
     in
     choice
-      [ (choice (holes !depth) >>= fun result -> (*Format.printf "Depth hole %d@." !depth;*) return result)
+      [ (choice (holes !depth) >>= fun result -> if debug then Format.printf "Depth hole %d@." !depth; return result)
       (* String literals are handled specially because match semantics change inside string delimiters. *)
       ; raw_string_literal_parser (generate_hole_for_literal Raw_string_literal)
       ; escapable_string_literal_parser (generate_hole_for_literal Escapable_string_literal)

--- a/lib/matchers/configuration.ml
+++ b/lib/matchers/configuration.ml
@@ -6,14 +6,17 @@ type t =
   { match_kind : match_kind
   ; significant_whitespace : bool
   ; disable_substring_matching : bool
+  ; cut_off_top_level_newline_matching : bool
   }
 
 let create
     ?(disable_substring_matching = false)
     ?(match_kind = Fuzzy)
     ?(significant_whitespace = false)
+    ?(cut_off_top_level_newline_matching = false)
     () =
   { match_kind
   ; significant_whitespace
   ; disable_substring_matching
+  ; cut_off_top_level_newline_matching
   }

--- a/lib/pipeline/pipeline.ml
+++ b/lib/pipeline/pipeline.ml
@@ -317,6 +317,7 @@ let run
         ; disable_substring_matching
         ; omega
         ; fast_offset_conversion
+        ; cut_off_newline
         }
     ; output_printer
     ; interactive_review
@@ -325,7 +326,13 @@ let run
   =
   let number_of_workers = if sequential then 0 else number_of_workers in
   let scheduler = Scheduler.create ~number_of_workers () in
-  let match_configuration = Configuration.create ~disable_substring_matching ~match_kind:Fuzzy () in
+  let match_configuration =
+    Configuration.create
+      ~disable_substring_matching
+      ~match_kind:Fuzzy
+      ~cut_off_top_level_newline_matching:cut_off_newline
+      ()
+  in
   let start_time = Statistics.Time.start () in
 
   let per_unit ~input ~path =

--- a/src/main.ml
+++ b/src/main.ml
@@ -103,6 +103,7 @@ let base_command_parameters : (unit -> 'result) Command.Param.t =
     and disable_substring_matching = flag "disable-substring-matching" no_arg ~doc:"Allow :[holes] to match substrings"
     and omega = flag "omega" no_arg  ~doc:"Use Omega matcher engine."
     and fast_offset_conversion = flag "fast-offset-conversion" no_arg ~doc:"Enable fast offset conversion. This is experimental and will become the default once vetted."
+    and cut_off_newline = flag "cut-off-newline" no_arg ~aliases:[] ~doc:"Disable matching newlines at the top level for hole."
     and anonymous_arguments =
       anon
         (maybe
@@ -203,6 +204,7 @@ let base_command_parameters : (unit -> 'result) Command.Param.t =
             ; disable_substring_matching
             ; omega
             ; fast_offset_conversion
+            ; cut_off_newline
             }
         ; output_options =
             { color

--- a/test/common/test_pipeline_alpha.ml
+++ b/test/common/test_pipeline_alpha.ml
@@ -20,6 +20,7 @@ let configuration =
       ; disable_substring_matching = false
       ; omega = false
       ; fast_offset_conversion = false
+      ; cut_off_newline = false
       }
   ; output_printer = (fun _ -> ())
   ; interactive_review = None

--- a/test/common/test_pipeline_omega.ml
+++ b/test/common/test_pipeline_omega.ml
@@ -20,6 +20,7 @@ let configuration =
       ; disable_substring_matching = false
       ; omega = false
       ; fast_offset_conversion = false
+      ; cut_off_newline = false
       }
   ; output_printer = (fun _ -> ())
   ; interactive_review = None


### PR DESCRIPTION
This reverts 16f8a20308f852300c2ac4b835686da65ca789f5 which was an unintended breaking change in how `:[_]` matches. It adds an opt-in flag `-cut-off-newline` that enables the behavior introduced in 16f8a20308f852300c2ac4b835686da65ca789f5.