### PR TITLE
Add delimiters for Julia

### DIFF
--- a/lib/matchers/languages.ml
+++ b/lib/matchers/languages.ml
@@ -690,7 +690,17 @@ module Julia = struct
 
   module Syntax = struct
     include Generic.Syntax
-
+    
+    Dyck.Syntax.user_defined_delimiters @
+      [ "if", "end"
+      ; "for", "end"
+      ; "while", "end"
+      ; "try", "end"
+      ; "struct", "end"
+      ; "begin", "end"
+      ; "let", "end"
+      ]
+      
     let comments =
       [ Nested_multiline ("#=", "=#")
       ; Until_newline "#"

--- a/lib/matchers/languages.ml
+++ b/lib/matchers/languages.ml
@@ -691,7 +691,9 @@ module Julia = struct
   module Syntax = struct
     include Generic.Syntax
     
-    Dyck.Syntax.user_defined_delimiters @
+    let user_defined_delimiters =
+      Generic.Syntax.user_defined_delimiters
+      @
       [ "if", "end"
       ; "for", "end"
       ; "while", "end"


### PR DESCRIPTION
For more details about Julia's delimiters, see <https://docs.julialang.org/en/v1/manual/control-flow> and <https://docs.julialang.org/en/v1/base/base/#let>.