### PR TITLE
install.sh: don't fail if no $TERM

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -17,7 +17,8 @@ function ctrl_c() {
 
 trap ctrl_c INT
 
-if which tput >/dev/null 2>&1; then
+colors=0
+if [ -z "$TERM" ] && which tput >/dev/null 2>&1; then
     colors=$(tput colors)
 fi
 if [ -t 1 ] && [ -n "$colors" ] && [ "$colors" -ge 8 ]; then


### PR DESCRIPTION
fixes #228

I tried locally:

```
$ TERM="" ./install.sh
[+] Downloading comby 0.x.0
[-] No binary release available for your system.
```
which is better, and expected.

However I am not sure the check is right for the value of TERM in the CI pipeline.