### PR TITLE
escape carriage return in matches

### DIFF
--- a/lib/match/match_context.ml
+++ b/lib/match/match_context.ml
@@ -99,6 +99,7 @@ let pp ppf (source_path, matches) =
     let matched =
       List.map matches ~f:(fun { matched; range; _ } ->
           let matched = String.substr_replace_all matched ~pattern:"\n" ~with_:"\\n" in
+          let matched = String.substr_replace_all matched ~pattern:"\r" ~with_:"\\r" in
           let line = range.match_start.line in
           Format.asprintf "%a%a%s" pp_source_path source_path pp_line_number line matched)
       |> String.concat ~sep:"\n"

--- a/test/common/test_cli.ml
+++ b/test/common/test_cli.ml
@@ -1017,6 +1017,17 @@ let%expect_test "substitute_ok" =
   [%expect_exact {|hole_1 hole_2
 |}]
 
+let%expect_test "escape_carriage-return" =
+  let source = "line1\r\nline2\r\n" in
+  let match_template = {|:[x\n]|} in
+  let command_args = Format.sprintf {|'%s' '' -stdin -match-only -matcher .c|} match_template in
+  let command = Format.sprintf "%s %s" binary_path command_args in
+  read_expect_stdin_and_stdout command source
+  |> print_string;
+  [%expect_exact {|1:line1\r\n
+2:line2\r\n
+|}]
+
 let%expect_test "diff_patches_with_trailing_newlines" =
   let source = "dont care" in
 


### PR DESCRIPTION
Fixes https://github.com/comby-tools/comby/issues/238. Fixes https://github.com/comby-tools/comby/issues/183.