### PR TITLE
make bisect_ppx pin a soft dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,4 @@ sudo: required
 before_install: 
     - make docker-test-build
 script:
-    - docker run -it -e TRAVIS_JOB_ID="$TRAVIS_JOB_ID" comby-local-test-build:latest /bin/bash -c "LIBRARY_PATH=/home/opam/.opam/4.09/lib/hack_parallel opam exec -- dune build --profile dev && opam exec -- dune clean && LIBRARY_PATH=/home/opam/.opam/4.09/lib/hack_parallel BISECT_ENABLE=yes dune build --profile dev && make comby comby-server benchmark && LIBRARY_PATH=/home/opam/.opam/4.09/lib/hack_parallel opam exec -- dune runtest && ./push-coverage-report.sh"
+    - docker run -it -e TRAVIS_JOB_ID="$TRAVIS_JOB_ID" comby-local-test-build:latest /bin/bash -c "opam exec -- make build && opam exec -- dune clean && opam exec -- make build-with-coverage && opam exec -- dune runtest && ./push-coverage-report.sh"

--- a/Makefile
+++ b/Makefile
@@ -1,19 +1,32 @@
 all: build comby comby-server benchmark
 
 build:
-	dune build --profile dev
+	@rm comby comby-server benchmark
+	@dune build --profile dev
+	@ln -sfn _build/install/default/bin/comby comby
+	@ln -sfn _build/install/default/bin/comby-server comby-server
+	@ln -sfn _build/install/default/bin/benchmark benchmark
 
 build-with-coverage:
+	@rm comby comby-server benchmark
 	@dune build --instrument-with bisect_ppx
+	@ln -sfn _build/install/default/bin/comby comby
+	@ln -sfn _build/install/default/bin/comby-server comby-server
+	@ln -sfn _build/install/default/bin/benchmark benchmark
 
 release:
+	@rm comby comby-server benchmark
 	@dune build --profile release
+	@ln -sfn _build/install/default/bin/comby comby
+	@ln -sfn _build/install/default/bin/comby-server comby-server
+	@ln -sfn _build/install/default/bin/benchmark benchmark
 
 byte:
 	@dune build src/main.bc
 
-comby comby-server benchmark:
-	@ln -s _build/install/default/bin/$@ ./$@
+# Uncomment this when dune is fixed: https://github.com/ocaml/dune/issues/4258
+# comby comby-server benchmark:
+#	@ln -s _build/install/default/bin/$@ ./$@
 
 run-server:
 	@./comby-server -p 8888
@@ -45,4 +58,4 @@ promote:
 docker-test-build:
 	docker build -t comby-local-test-build .
 
-.PHONY: all build build-with-coverage release run-server run-staging-server install doc test coverage clean uninstall promote docker-test-build
+.PHONY: all build build-with-coverage release run-server run-staging-server install doc test coverage clean uninstall promote docker-test-build comby comby-server benchmark

--- a/Makefile
+++ b/Makefile
@@ -1,21 +1,21 @@
-all: build comby comby-server benchmark
+all: build
 
 build:
-	@rm comby comby-server benchmark
+	@rm -rf comby comby-server benchmark
 	@dune build --profile dev
 	@ln -sfn _build/install/default/bin/comby comby
 	@ln -sfn _build/install/default/bin/comby-server comby-server
 	@ln -sfn _build/install/default/bin/benchmark benchmark
 
 build-with-coverage:
-	@rm comby comby-server benchmark
+	@rm -rf comby comby-server benchmark
 	@dune build --instrument-with bisect_ppx
 	@ln -sfn _build/install/default/bin/comby comby
 	@ln -sfn _build/install/default/bin/comby-server comby-server
 	@ln -sfn _build/install/default/bin/benchmark benchmark
 
 release:
-	@rm comby comby-server benchmark
+	@rm -rf comby comby-server benchmark
 	@dune build --profile release
 	@ln -sfn _build/install/default/bin/comby comby
 	@ln -sfn _build/install/default/bin/comby-server comby-server

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ build:
 	dune build --profile dev
 
 build-with-coverage:
-	@BISECT_ENABLE=yes dune build --profile dev
+	@dune build --instrument-with bisect_ppx
 
 release:
 	@dune build --profile release

--- a/comby.opam
+++ b/comby.opam
@@ -13,7 +13,7 @@ depends: [
   "ocaml" {>= "4.08.1"}
   "core"
   "lwt" {= "4.5.0"}
-  "conduit-lwt-unix" {= "2.0.2"}
+  "conduit-lwt-unix"
   "hack_parallel"
   "mparser-comby"
   "ppxlib"
@@ -29,7 +29,6 @@ depends: [
   "lwt_react"
   "ppx_deriving_yojson" {>= "3.6.0"}
   "toml" {>= "6.0.0"}
-  "ppx_tools_versioned" {>= "5.2.3"}
   "dune" {>= "2.7.0"}
   "bisect_ppx" {with-test & dev & >= "2.5.0"}
 ]

--- a/comby.opam
+++ b/comby.opam
@@ -36,9 +36,9 @@ depends: [
 pin-depends: [
   ["bisect_ppx.git" "git+https://github.com/aantron/bisect_ppx.git"]
   ["mparser-comby.git" "git+https://github.com/comby-tools/mparser.git"]
-  ["patdiff.git" "git+https://github.com/rvantonder/patdiff.git#0.13.0-patch-compatible-diffs"]
+  ["patdiff.git" "git+https://github.com/rvantonder/patdiff.git#0.14.0-patch-compatible-diffs"]
   ["camlzip.git" "git+https://github.com/rvantonder/camlzip.git#zip64"]
-  ["hack_parallel.git" "git+https://github.com/rvantonder/hack_parallel.git#4.10"]
+  ["hack_parallel.git" "git+https://github.com/rvantonder/hack_parallel.git#4.10-unconstrained-core"]
 ]
 depexts: [
     [

--- a/comby.opam
+++ b/comby.opam
@@ -27,10 +27,11 @@ depends: [
   "shell"
   "patdiff"
   "lwt_react"
-  "ppx_deriving_yojson"
-  "toml"
+  "ppx_deriving_yojson" {>= "3.6.0"}
+  "toml" {>= "6.0.0"}
   "ppx_tools_versioned" {>= "5.2.3"}
-  "bisect_ppx" {dev & >= "2.0.0"}
+  "dune" {>= "2.7.0"}
+  "bisect_ppx" {with-test & dev & >= "2.5.0"}
 ]
 pin-depends: [
   ["bisect_ppx.git" "git+https://github.com/aantron/bisect_ppx.git"]

--- a/dockerfiles/alpine/base-dependencies/Dockerfile
+++ b/dockerfiles/alpine/base-dependencies/Dockerfile
@@ -30,6 +30,6 @@ COPY push-coverage-report.sh /home/comby/
 RUN sudo chown -R $(whoami) /home/comby
 
 # Build and install the OCaml dependencies.
-RUN eval $(opam env) && opam repository set-url default https://opam.ocaml.org && opam update && opam install . --deps-only -y
+RUN eval $(opam env) && opam repository set-url default https://opam.ocaml.org && opam update && opam install . --deps-only --with-test -y
 # Delete the source files
 RUN sudo rm -rf /home/comby

--- a/dockerfiles/alpine/binary-release/Dockerfile
+++ b/dockerfiles/alpine/binary-release/Dockerfile
@@ -16,10 +16,11 @@ COPY test /home/comby/test
 COPY push-coverage-report.sh /home/comby/
 
 RUN sudo chown -R $(whoami) /home/comby
-RUN opam exec -- dune build --profile dev
-RUN make comby comby-server benchmark
+RUN opam exec -- make build
 RUN opam exec -- dune runtest
 RUN opam exec -- dune clean
+# UGH. stop dune from complaining
+RUN rm -rf comby comby-server benchmark
 RUN opam exec -- dune build --profile release
 
 ###################################################

--- a/dockerfiles/ubuntu/binary-release/Dockerfile
+++ b/dockerfiles/ubuntu/binary-release/Dockerfile
@@ -25,10 +25,11 @@ COPY push-coverage-report.sh /home/comby/
 
 RUN sudo chown -R $(whoami) /home/comby
 RUN eval $(opam env) && opam install . --deps-only -y
-RUN opam exec -- dune build --profile dev
-RUN make comby comby-server benchmark
+RUN opam exec -- make build
 RUN opam exec -- dune runtest
 RUN opam exec -- dune clean
+# UGH. stop dune from complaining
+RUN rm -rf comby comby-server benchmark
 RUN opam exec -- dune build --profile release
 
 # The binary is now available in /home/comby/_build/default/src/main.exe

--- a/dune-project
+++ b/dune-project
@@ -1,2 +1,2 @@
-(lang dune 1.9)
+(lang dune 2.7)
 (name comby)

--- a/lib/configuration/command_configuration.ml
+++ b/lib/configuration/command_configuration.ml
@@ -53,7 +53,7 @@ let parse_source_directories
           (String.contains path '/' && Sys.is_file path = `Yes)
           || (Sys.is_file ("." ^/ path) = `Yes) (* See if it matches something in the current directory *)
         in
-        if is_exact path then `Fst path else `Snd path)
+        if is_exact path then Either.First path else Either.Second path)
   in
   let f acc ~depth ~absolute_path ~is_file =
     if depth > max_depth then

--- a/lib/configuration/diff_configuration.ml
+++ b/lib/configuration/diff_configuration.ml
@@ -42,8 +42,8 @@ let default context =
 )|} context
 
 let terminal ?(context = 16) () =
-  Patdiff_lib.Configuration.Config.t_of_sexp (Sexp.of_string (default context))
-  |> Patdiff_lib.Configuration.parse
+  Patdiff.Configuration.On_disk.t_of_sexp (Sexp.of_string (default context))
+  |> Patdiff.Configuration.parse
 
 let diff_configuration =
   {|;; -*- scheme -*-
@@ -82,8 +82,8 @@ let diff_configuration =
 )|}
 
 let match_diff () =
-  Patdiff_lib.Configuration.Config.t_of_sexp (Sexp.of_string diff_configuration)
-  |> Patdiff_lib.Configuration.parse
+  Patdiff.Configuration.On_disk.t_of_sexp (Sexp.of_string diff_configuration)
+  |> Patdiff.Configuration.parse
 
 (* Needs (unrefined true), otherwise it just prints without colors. Unrefined true
    will diff on a line basis. line_unified is ignored for unrefined, but
@@ -125,8 +125,8 @@ let plain_configuration =
 |}
 
 let plain () =
-  Patdiff_lib.Configuration.Config.t_of_sexp (Sexp.of_string plain_configuration)
-  |> Patdiff_lib.Configuration.parse
+  Patdiff.Configuration.On_disk.t_of_sexp (Sexp.of_string plain_configuration)
+  |> Patdiff.Configuration.parse
 
 type kind =
   | Plain
@@ -136,7 +136,7 @@ type kind =
   | Match_only
 
 let get_diff kind source_path source_content result =
-  let open Patdiff_lib in
+  let open Patdiff in
   let source_path =
     match source_path with
     | Some path -> path
@@ -150,8 +150,8 @@ let get_diff kind source_path source_content result =
     | Default -> terminal ~context:3 ()
     | Match_only -> match_diff ()
   in
-  let prev = Patdiff_core.{ name = source_path; text = source_content } in
-  let next = Patdiff_core.{ name = source_path; text = result } in
+  let prev = Patdiff.Diff_input.{ name = source_path; text = source_content } in
+  let next = Patdiff.Diff_input.{ name = source_path; text = result } in
 
   Compare_core.diff_strings ~print_global_header:true configuration ~prev ~next
   |> function

--- a/lib/configuration/dune
+++ b/lib/configuration/dune
@@ -1,5 +1,6 @@
 (library
   (name configuration)
   (public_name comby.configuration)
-  (preprocess (pps ppx_deriving.show ppx_sexp_conv ppx_sexp_message ppx_deriving_yojson bisect_ppx --conditional))
+  (instrumentation (backend bisect_ppx))
+  (preprocess (pps ppx_deriving.show ppx_sexp_conv ppx_sexp_message ppx_deriving_yojson))
   (libraries camlzip comby.statistics comby.parsers comby.match comby.language ppxlib core core.uuid mparser mparser.pcre yojson ppx_deriving_yojson hack_parallel toml lwt lwt.unix))

--- a/lib/configuration/dune
+++ b/lib/configuration/dune
@@ -3,4 +3,4 @@
   (public_name comby.configuration)
   (instrumentation (backend bisect_ppx))
   (preprocess (pps ppx_deriving.show ppx_sexp_conv ppx_sexp_message ppx_deriving_yojson))
-  (libraries camlzip comby.statistics comby.parsers comby.match comby.language ppxlib core core.uuid mparser mparser.pcre yojson ppx_deriving_yojson hack_parallel toml lwt lwt.unix))
+  (libraries camlzip comby.statistics comby.parsers comby.match comby.language ppxlib core core.uuid mparser mparser.pcre yojson ppx_deriving_yojson hack_parallel toml lwt lwt.unix patdiff))

--- a/lib/dune
+++ b/lib/dune
@@ -1,7 +1,8 @@
 (library
   (name comby)
   (public_name comby)
-  (preprocess (pps ppx_deriving.show ppx_deriving.eq ppx_sexp_conv bisect_ppx --conditional))
+  (instrumentation (backend bisect_ppx))
+  (preprocess (pps ppx_deriving.show ppx_deriving.eq ppx_sexp_conv))
   (libraries 
    ppxlib 
    core 

--- a/lib/language/dune
+++ b/lib/language/dune
@@ -1,5 +1,6 @@
 (library
   (name language)
   (public_name comby.language)
-  (preprocess (pps ppx_sexp_conv bisect_ppx --conditional))
+  (instrumentation (backend bisect_ppx))
+  (preprocess (pps ppx_sexp_conv))
   (libraries comby.parsers comby.match comby.rewriter ppxlib core core.uuid))

--- a/lib/match/dune
+++ b/lib/match/dune
@@ -1,5 +1,6 @@
 (library
   (name match)
   (public_name comby.match)
-  (preprocess (pps ppx_deriving.eq ppx_sexp_conv ppx_deriving_yojson bisect_ppx --conditional))
+  (instrumentation (backend bisect_ppx))
+  (preprocess (pps ppx_deriving.eq ppx_sexp_conv ppx_deriving_yojson))
   (libraries comby.parsers ppxlib core yojson ppx_deriving_yojson ppx_deriving_yojson.runtime))

--- a/lib/matchers/dune
+++ b/lib/matchers/dune
@@ -1,5 +1,6 @@
 (library
   (name matchers)
   (public_name comby.matchers)
-  (preprocess (pps ppx_here ppx_sexp_conv ppx_sexp_message ppx_deriving_yojson bisect_ppx --conditional))
+  (instrumentation (backend bisect_ppx))
+  (preprocess (pps ppx_here ppx_sexp_conv ppx_sexp_message ppx_deriving_yojson))
   (libraries comby.parsers comby.match angstrom ppxlib core core.uuid mparser mparser.pcre yojson ppx_deriving_yojson))

--- a/lib/parsers/dune
+++ b/lib/parsers/dune
@@ -1,5 +1,6 @@
 (library
   (name parsers)
   (public_name comby.parsers)
-  (preprocess (pps ppx_sexp_conv bisect_ppx --conditional))
+  (instrumentation (backend bisect_ppx))
+  (preprocess (pps ppx_sexp_conv))
   (libraries angstrom ppxlib core mparser mparser.pcre))

--- a/lib/pipeline/dune
+++ b/lib/pipeline/dune
@@ -1,5 +1,6 @@
 (library
   (name pipeline)
   (public_name comby.pipeline)
-  (preprocess (pps ppx_sexp_conv ppx_deriving_yojson bisect_ppx --conditional))
+  (instrumentation (backend bisect_ppx))
+  (preprocess (pps ppx_sexp_conv ppx_deriving_yojson))
   (libraries comby.configuration comby.interactive comby.statistics comby.parsers comby.match comby.language camlzip ppxlib core yojson ppx_deriving_yojson hack_parallel))

--- a/lib/replacement/dune
+++ b/lib/replacement/dune
@@ -3,4 +3,4 @@
   (public_name comby.replacement)
   (instrumentation (backend bisect_ppx))
   (preprocess (pps ppx_deriving_yojson))
-  (libraries comby.match ppxlib core yojson ppx_deriving_yojson ppx_deriving_yojson.runtime patdiff.lib))
+  (libraries comby.match ppxlib core yojson ppx_deriving_yojson ppx_deriving_yojson.runtime))

--- a/lib/replacement/dune
+++ b/lib/replacement/dune
@@ -1,5 +1,6 @@
 (library
   (name replacement)
   (public_name comby.replacement)
-  (preprocess (pps ppx_deriving_yojson bisect_ppx --conditional))
+  (instrumentation (backend bisect_ppx))
+  (preprocess (pps ppx_deriving_yojson))
   (libraries comby.match ppxlib core yojson ppx_deriving_yojson ppx_deriving_yojson.runtime patdiff.lib))

--- a/lib/rewriter/dune
+++ b/lib/rewriter/dune
@@ -1,5 +1,6 @@
 (library
   (name rewriter)
   (public_name comby.rewriter)
-  (preprocess (pps ppx_deriving_yojson bisect_ppx --conditional))
+  (instrumentation (backend bisect_ppx))
+  (preprocess (pps ppx_deriving_yojson))
   (libraries comby.matchers comby.replacement ppxlib core core.uuid))

--- a/lib/server/dune
+++ b/lib/server/dune
@@ -1,5 +1,6 @@
 (library
   (name server_types)
   (public_name comby.server_types)
-  (preprocess (pps ppx_deriving.show ppx_deriving_yojson bisect_ppx --conditional))
+  (instrumentation (backend bisect_ppx))
+  (preprocess (pps ppx_deriving.show ppx_deriving_yojson))
   (libraries comby.match comby.replacement ppxlib core yojson ppx_deriving_yojson ppx_deriving_yojson.runtime))

--- a/lib/statistics/dune
+++ b/lib/statistics/dune
@@ -1,5 +1,6 @@
 (library
   (name statistics)
   (public_name comby.statistics)
-  (preprocess (pps ppx_deriving_yojson bisect_ppx --conditional))
+  (instrumentation (backend bisect_ppx))
+  (preprocess (pps ppx_deriving_yojson))
   (libraries yojson ppx_deriving_yojson ppx_deriving_yojson.runtime))

--- a/push-coverage-report.sh
+++ b/push-coverage-report.sh
@@ -1,9 +1,6 @@
 #!/bin/bash
 
-bisect-ppx-report \
-    -I _build/default/ \
-    --coveralls coverage.json \
-    --service-name travis-ci \
-    --service-job-id $TRAVIS_JOB_ID \
-    `find . -name 'bisect*.out'`
-curl -L -F json_file=@./coverage.json https://coveralls.io/api/v1/jobs
+bisect-ppx-report send-to Coveralls
+echo $?
+bisect-ppx-report send-to Codecov
+echo $?

--- a/src/dune
+++ b/src/dune
@@ -1,5 +1,5 @@
 (executables
- (libraries comby core ppx_deriving_yojson ppx_deriving_yojson.runtime hack_parallel camlzip patdiff.lib) 
+ (libraries comby core ppx_deriving_yojson ppx_deriving_yojson.runtime hack_parallel camlzip patdiff)
  (preprocess (pps ppx_deriving_yojson ppx_let ppx_deriving.show ppx_sexp_conv))
  (modules main)
  (modes byte exe)

--- a/test/alpha/dune
+++ b/test/alpha/dune
@@ -6,7 +6,7 @@
   test_substring_disabled
   test_regex_holes)
  (inline_tests)
- (preprocess (pps ppx_expect ppx_sexp_message ppx_deriving_yojson ppx_deriving_yojson.runtime))
+ (preprocess (pps ppx_expect ppx_sexp_message ppx_deriving_yojson))
  (libraries
   comby
   cohttp-lwt-unix

--- a/test/common/dune
+++ b/test/common/dune
@@ -62,7 +62,7 @@
   test_nested_matches_omega
   )
  (inline_tests)
- (preprocess (pps ppx_expect ppx_sexp_message ppx_deriving_yojson ppx_deriving_yojson.runtime))
+ (preprocess (pps ppx_expect ppx_sexp_message ppx_deriving_yojson))
  (libraries
   comby
   cohttp-lwt-unix

--- a/test/omega/dune
+++ b/test/omega/dune
@@ -8,7 +8,7 @@
   test_special_matcher_cases
   test_substring_disabled)
  (inline_tests)
- (preprocess (pps ppx_expect ppx_sexp_message ppx_deriving_yojson ppx_deriving_yojson.runtime))
+ (preprocess (pps ppx_expect ppx_sexp_message ppx_deriving_yojson))
  (libraries
   comby
   cohttp-lwt-unix


### PR DESCRIPTION
- Upgrades to recent `bisect_ppx`
- Updates `patdiff` and `hack_parallel` changes
- Had to change symlink/make commands because of dune issue `https://github.com/ocaml/dune/issues/4258`
- Compiles with (at least) `4.11`, `4.10`.