### PR TITLE
Add instruction to eval opam env variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,8 @@ git clone https://github.com/comby-tools/comby
 cd comby && opam install . --deps-only -y
 ```
 
+- Run `eval $(opam env)`
+
 - Build and test
 
 ```


### PR DESCRIPTION
When building from source, the `opam install . --deps-only -y` command
will output this in the end if it completes successfully: 

```
# Run eval $(opam env) to update the current shell environment 
```

This is easy to miss when following the "next step" from this
README. Adding it as an explicit step would help avoid running into
errors during `make`.