### PR TITLE
Fix string escaping for `-json-lines`

### DIFF
--- a/lib/kernel/match/match_context.ml
+++ b/lib/kernel/match/match_context.ml
@@ -68,8 +68,8 @@ let to_json source_path matches =
   let json_matches matches =
     matches
     |> List.map ~f:(fun m ->
-        { m with matched = String.escaped m.matched;
-                 environment = update_environment String.escaped m.environment })
+        { m with matched = m.matched;
+                 environment = update_environment (fun x -> x) m.environment })
     |> List.map ~f:to_yojson
     |> fun matches ->
     `List matches


### PR DESCRIPTION
Comby double-escapes some values when encoding the matches as JSON, which makes it difficult to do any further processing on, particularly since the `String.escaped` method doesn't necessarily have a counterpart `unescape` in other languages. 

This removes the string escaping from the JSON encoding so the string in the field's value is decodable as the raw file content.

<details>
<summary>Before:</summary>

```
❯ comby -match-only -json-lines 'LineMatch{...}' '' ./cmd/searcher/internal/search/search_structural.go | jq ''
{
  "uri": "/Users/camdencheek/src/sourcegraph/sourcegraph/cmd/searcher/internal/search/search_structural.go",
  "matches": [
    {
      "range": {
        "start": {
          "offset": 1152,
          "line": 32,
          "column": 21
        },
        "end": {
          "offset": 1376,
          "line": 43,
          "column": 4
        }
      },
      "environment": [
        {
          "variable": "_",
          "value": "\\n\\t\\t\\t{\\n\\t\\t\\t\\tLineNumber: r.Range.Start.Line - 1,\\n\\t\\t\\t\\tOffsetAndLengths: [][2]int{\\n\\t\\t\\t\\t\\t{\\n\\t\\t\\t\\t\\t\\tr.Range.Start.Column - 1,\\n\\t\\t\\t\\t\\t\\tr.Range.End.Column - r.Range.Start.Column,\\n\\t\\t\\t\\t\\t},\\n\\t\\t\\t\\t},\\n\\t\\t\\t\\tPreview: r.Matched,\\n\\t\\t\\t},\\n\\t\\t",
          "range": {
            "start": {
              "offset": 1162,
              "line": 32,
              "column": 31
            },
            "end": {
              "offset": 1375,
              "line": 43,
              "column": 3
            }
          }
        }
      ],
      "matched": "LineMatch{\\n\\t\\t\\t{\\n\\t\\t\\t\\tLineNumber: r.Range.Start.Line - 1,\\n\\t\\t\\t\\tOffsetAndLengths: [][2]int{\\n\\t\\t\\t\\t\\t{\\n\\t\\t\\t\\t\\t\\tr.Range.Start.Column - 1,\\n\\t\\t\\t\\t\\t\\tr.Range.End.Column - r.Range.Start.Column,\\n\\t\\t\\t\\t\\t},\\n\\t\\t\\t\\t},\\n\\t\\t\\t\\tPreview: r.Matched,\\n\\t\\t\\t},\\n\\t\\t}"
    },
    {
      "range": {
        "start": {
          "offset": 1860,
          "line": 63,
          "column": 38
        },
        "end": {
          "offset": 2019,
          "line": 72,
          "column": 4
        }
      },
      "environment": [
        {
          "variable": "_",
          "value": "\\n\\t\\t\\tLineNumber: r.Range.Start.Line + i - 1,\\n\\t\\t\\tOffsetAndLengths: [][2]int{\\n\\t\\t\\t\\t{\\n\\t\\t\\t\\t\\tcolumnStart,\\n\\t\\t\\t\\t\\tcolumnEnd,\\n\\t\\t\\t\\t},\\n\\t\\t\\t},\\n\\t\\t\\tPreview: line,\\n\\t\\t",
          "range": {
            "start": {
              "offset": 1870,
              "line": 63,
              "column": 48
            },
            "end": {
              "offset": 2018,
              "line": 72,
              "column": 3
            }
          }
        }
      ],
      "matched": "LineMatch{\\n\\t\\t\\tLineNumber: r.Range.Start.Line + i - 1,\\n\\t\\t\\tOffsetAndLengths: [][2]int{\\n\\t\\t\\t\\t{\\n\\t\\t\\t\\t\\tcolumnStart,\\n\\t\\t\\t\\t\\tcolumnEnd,\\n\\t\\t\\t\\t},\\n\\t\\t\\t},\\n\\t\\t\\tPreview: line,\\n\\t\\t}"
    }
  ]
}

```
</details>

<details>
<summary>After:</summary>

```
❯ comby -match-only -json-lines 'LineMatch{...}' '' ./cmd/searcher/internal/search/search_structural.go | jq ''
{
  "uri": "/Users/camdencheek/src/sourcegraph/sourcegraph/cmd/searcher/internal/search/search_structural.go",
  "matches": [
    {
      "range": {
        "start": {
          "offset": 1152,
          "line": 32,
          "column": 21
        },
        "end": {
          "offset": 1376,
          "line": 43,
          "column": 4
        }
      },
      "environment": [
        {
          "variable": "_",
          "value": "\n\t\t\t{\n\t\t\t\tLineNumber: r.Range.Start.Line - 1,\n\t\t\t\tOffsetAndLengths: [][2]int{\n\t\t\t\t\t{\n\t\t\t\t\t\tr.Range.Start.Column - 1,\n\t\t\t\t\t\tr.Range.End.Column - r.Range.Start.Column,\n\t\t\t\t\t},\n\t\t\t\t},\n\t\t\t\tPreview: r.Matched,\n\t\t\t},\n\t\t",
          "range": {
            "start": {
              "offset": 1162,
              "line": 32,
              "column": 31
            },
            "end": {
              "offset": 1375,
              "line": 43,
              "column": 3
            }
          }
        }
      ],
      "matched": "LineMatch{\n\t\t\t{\n\t\t\t\tLineNumber: r.Range.Start.Line - 1,\n\t\t\t\tOffsetAndLengths: [][2]int{\n\t\t\t\t\t{\n\t\t\t\t\t\tr.Range.Start.Column - 1,\n\t\t\t\t\t\tr.Range.End.Column - r.Range.Start.Column,\n\t\t\t\t\t},\n\t\t\t\t},\n\t\t\t\tPreview: r.Matched,\n\t\t\t},\n\t\t}"
    },
    {
      "range": {
        "start": {
          "offset": 1860,
          "line": 63,
          "column": 38
        },
        "end": {
          "offset": 2019,
          "line": 72,
          "column": 4
        }
      },
      "environment": [
        {
          "variable": "_",
          "value": "\n\t\t\tLineNumber: r.Range.Start.Line + i - 1,\n\t\t\tOffsetAndLengths: [][2]int{\n\t\t\t\t{\n\t\t\t\t\tcolumnStart,\n\t\t\t\t\tcolumnEnd,\n\t\t\t\t},\n\t\t\t},\n\t\t\tPreview: line,\n\t\t",
          "range": {
            "start": {
              "offset": 1870,
              "line": 63,
              "column": 48
            },
            "end": {
              "offset": 2018,
              "line": 72,
              "column": 3
            }
          }
        }
      ],
      "matched": "LineMatch{\n\t\t\tLineNumber: r.Range.Start.Line + i - 1,\n\t\t\tOffsetAndLengths: [][2]int{\n\t\t\t\t{\n\t\t\t\t\tcolumnStart,\n\t\t\t\t\tcolumnEnd,\n\t\t\t\t},\n\t\t\t},\n\t\t\tPreview: line,\n\t\t}"
    }
  ]
}
```

</details>
