### PR TITLE
Use `Yojson.Safe.t` for compatibility with Yojson 2

### DIFF
--- a/comby-kernel.opam
+++ b/comby-kernel.opam
@@ -25,6 +25,7 @@ depends: [
   "mparser-pcre"
   "ppx_deriving"
   "ppx_deriving_yojson" {>= "3.6.0"}
+  "yojson" {>= "1.6.0"}
   "pcre"
   # vendored dependencies
   "bigstringaf"

--- a/comby.opam
+++ b/comby.opam
@@ -41,6 +41,7 @@ depends: [
   "patience_diff" {>= "v0.14" & < "v0.15"}
   "ppx_deriving"
   "ppx_deriving_yojson" {>= "3.6.0"}
+  "yojson" {>= "1.6.0"}
   "pcre"
   "shell"
   "tar"

--- a/lib/kernel/comby_kernel.mli
+++ b/lib/kernel/comby_kernel.mli
@@ -17,8 +17,8 @@ module Match : sig
       }
     [@@deriving eq, sexp]
 
-    val to_yojson : t -> Yojson.Safe.json
-    val of_yojson : Yojson.Safe.json -> (t, string) Result.t
+    val to_yojson : t -> Yojson.Safe.t
+    val of_yojson : Yojson.Safe.t -> (t, string) Result.t
 
     val default : t
   end
@@ -33,8 +33,8 @@ module Match : sig
       }
     [@@deriving eq, sexp]
 
-    val to_yojson : t -> Yojson.Safe.json
-    val of_yojson : Yojson.Safe.json -> (t, string) Result.t
+    val to_yojson : t -> Yojson.Safe.t
+    val of_yojson : Yojson.Safe.t -> (t, string) Result.t
 
     val default : t
   end
@@ -49,8 +49,8 @@ module Match : sig
     type t
     [@@deriving eq]
 
-    val to_yojson : t -> Yojson.Safe.json
-    val of_yojson : Yojson.Safe.json -> (t, string) Result.t
+    val to_yojson : t -> Yojson.Safe.t
+    val of_yojson : Yojson.Safe.t -> (t, string) Result.t
 
     (** [create] creates a new, empty environment *)
     val create : unit -> t
@@ -100,8 +100,8 @@ module Match : sig
     ; matched : string
     }
 
-  val to_yojson : t -> Yojson.Safe.json
-  val of_yojson : Yojson.Safe.json -> (t, string) Result.t
+  val to_yojson : t -> Yojson.Safe.t
+  val of_yojson : Yojson.Safe.t -> (t, string) Result.t
 
   (** [create] creates a new match with empty range by default. *)
   val create : ?range:range -> unit -> t
@@ -137,8 +137,8 @@ module Replacement : sig
     ; environment : Match.environment
     }
 
-  val to_yojson : t -> Yojson.Safe.json
-  val of_yojson : Yojson.Safe.json -> (t, string) Result.t
+  val to_yojson : t -> Yojson.Safe.t
+  val of_yojson : Yojson.Safe.t -> (t, string) Result.t
 
   val to_json
     :  ?path:string
@@ -146,7 +146,7 @@ module Replacement : sig
     -> ?rewritten_source:string
     -> diff:string
     -> unit
-    -> Yojson.Safe.json
+    -> Yojson.Safe.t
 
   (** A replacement result is the rewritten source, and the replacement
       fragments. *)
@@ -155,7 +155,7 @@ module Replacement : sig
     ; in_place_substitutions : t list
     }
 
-  val result_to_yojson : result -> Yojson.Safe.json
+  val result_to_yojson : result -> Yojson.Safe.t
 
 end
 
@@ -296,8 +296,8 @@ module Matchers : sig
       ; aliases : alias list
       }
 
-    val to_yojson : t -> Yojson.Safe.json
-    val of_yojson : Yojson.Safe.json -> (t, string) Result.t
+    val to_yojson : t -> Yojson.Safe.t
+    val of_yojson : Yojson.Safe.t -> (t, string) Result.t
 
     (** A module signature for metasyntax to parameterize a matcher *)
     module type S = sig
@@ -584,8 +584,8 @@ module Matchers : sig
         ; comments : comment_kind list
         }
 
-      val to_yojson : t -> Yojson.Safe.json
-      val of_yojson : Yojson.Safe.json -> (t, string) Result.t
+      val to_yojson : t -> Yojson.Safe.t
+      val of_yojson : Yojson.Safe.t -> (t, string) Result.t
 
       (** The module signature that defines language syntax for a matcher *)
       module type S = sig

--- a/lib/kernel/dune
+++ b/lib/kernel/dune
@@ -7,4 +7,5 @@
    core_kernel
    comby-kernel.match
    comby-kernel.matchers
-   comby-kernel.replacement))
+   comby-kernel.replacement
+   yojson))

--- a/lib/kernel/match/environment.ml
+++ b/lib/kernel/match/environment.ml
@@ -67,7 +67,7 @@ let copy env =
 let exists env key =
   Option.is_some (lookup env key)
 
-let to_yojson env : Yojson.Safe.json =
+let to_yojson env : Yojson.Safe.t =
   let s =
     Map.fold_right env ~init:[] ~f:(fun ~key:variable ~data:{value; range} acc ->
         let item =
@@ -81,7 +81,7 @@ let to_yojson env : Yojson.Safe.json =
   in
   `List s
 
-let of_yojson (json : Yojson.Safe.json) =
+let of_yojson (json : Yojson.Safe.t) =
   let open Yojson.Safe.Util in
   let env = create () in
   match json with

--- a/lib/kernel/replacement/replacement.mli
+++ b/lib/kernel/replacement/replacement.mli
@@ -19,6 +19,6 @@ val to_json
   -> ?rewritten_source:string
   -> diff:string
   -> unit
-  -> Yojson.Safe.json
+  -> Yojson.Safe.t
 
 val empty_result : result


### PR DESCRIPTION
This also adds the dependency directly instead of pulling it via ppx_deriving_yojson.