### PR TITLE
Flush output on each match

### DIFF
--- a/lib/app/configuration/command_configuration.ml
+++ b/lib/app/configuration/command_configuration.ml
@@ -314,14 +314,14 @@ module Printer = struct
         let ppf = Format.std_formatter in
         match match_output with
         | Match_only Contents ->
-          Format.fprintf ppf "%a" Match.pp (source_path, matches)
+          Format.fprintf ppf "%a%!" Match.pp (source_path, matches)
         | Match_only Count ->
-          Format.fprintf ppf "%a" Match.pp_match_count (source_path, matches)
+          Format.fprintf ppf "%a%!" Match.pp_match_count (source_path, matches)
         | Json_lines ->
-          Format.fprintf ppf "%a" Match.pp_json_lines (source_path, matches)
+          Format.fprintf ppf "%a%!" Match.pp_json_lines (source_path, matches)
         | Match_only Chunk_matches threshold ->
           let chunk_matches = Match.to_chunks ?threshold source_content matches in
-          Format.fprintf ppf "%a" Match.pp_chunk_matches (source_path, chunk_matches)
+          Format.fprintf ppf "%a%!" Match.pp_chunk_matches (source_path, chunk_matches)
   end
 
   module Rewrite : sig


### PR DESCRIPTION
This updates the formatting code to flush the output after each result. We do this for two reasons:
1) It ensures we actually stream results rather than buffering them in `comby` while it waits for more input, and
2) This may be causing incomplete JSON to be written to `stdout`.

Additionally, from a few other investigations, it appears comby might not be flushing the output before exiting, which means it's possible to lose some results (buffered results that haven't yet been flushed). This solves that problem by flushing on every match, but that comes with a small performance penalty. I think that's a fair price to pay for incremental streaming.