### PR TITLE
Use `= version` for local dependencies

### DIFF
--- a/comby.opam
+++ b/comby.opam
@@ -29,8 +29,8 @@ depends: [
   "conf-sqlite3"
   "conf-zlib" {os = "linux"}
   "cohttp-lwt-unix"
-  "comby-kernel" {= "1.7.0"}
-  "comby-semantic" {= "1.7.0"}
+  "comby-kernel" {= version}
+  "comby-semantic" {= version}
   "core"
   "hack_parallel" {arch != "arm32" & arch != "arm64"}
   "lwt"


### PR DESCRIPTION
Replace hardcoded version numbers for local dependencies with the `version` opam variable. This is required for local development with dune packagement, as the version of a package is not stored in the source code.